### PR TITLE
Fix: LoginView -> MainTab 이동시 뒤로가기 버튼 없애기

### DIFF
--- a/DogWalk/Application/Coordinator/DogWalkCoordinatorProtocol.swift
+++ b/DogWalk/Application/Coordinator/DogWalkCoordinatorProtocol.swift
@@ -19,7 +19,7 @@ protocol DogWalkCoordinatorProtocol: ObservableObject {
     func popToRoot() // 홈화면으로 이동
     func dismissSheet() // 시트 내리기
     func dismissFullScreenOver() // 풀스크린 커버 내리기
-    
+    func changeTab(tab: Tab)
 }
 
 //MARK: 필요한 뷰 추가해서 사용
@@ -77,3 +77,5 @@ enum FullScreenCover:  Identifiable, Hashable {
     
     case dogWalkResult(walkTime: Int, walkDistance: Double, routeImage: UIImage)
 }
+
+

--- a/DogWalk/Application/Coordinator/MainCoordinator.swift
+++ b/DogWalk/Application/Coordinator/MainCoordinator.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 final class MainCoordinator: DogWalkCoordinatorProtocol {
+    
     @Published var path: NavigationPath = NavigationPath()
     @Published var sheet: Sheet?
     @Published var fullScreenCover: FullScreenCover?
-    @Published var selectedTab: Tab?
+    @Published var selectedTab: Tab = .home
     
     func push(_ screen: Screen) {
         path.append(screen)
@@ -46,11 +47,15 @@ final class MainCoordinator: DogWalkCoordinatorProtocol {
         //path.append(Screen.tab)
     }
     
+    func changeTab(tab: Tab) {
+            selectedTab = tab 
+        }
+    
     // 화면
     @ViewBuilder
     func build(_ screen: Screen) -> some View {
         switch screen {
-        case .tab: CustomTabView()                      // 탭
+        case .tab: MainTabView(coordinator: self)                      // 탭
         case .auth: AuthView()                          // 회원가입
         case .login: LoginView.build()                  // 로그인
         case .home: HomeView.build()                          // 홈

--- a/DogWalk/Presentatiton/Screens/CustomTab/CustomTabView.swift
+++ b/DogWalk/Presentatiton/Screens/CustomTab/CustomTabView.swift
@@ -7,38 +7,44 @@
 
 import SwiftUI
 
-struct CustomTabView: View {
+struct MainTabView: View {
+    @ObservedObject var coordinator: MainCoordinator // Coordinator 주입
+
     var body: some View {
-        TabView {
-            HomeView.build()
+        TabView(selection: $coordinator.selectedTab) {
+            coordinator.build(.home) // 홈 화면 생성
                 .tabItem {
                     Image.asWalk
                         .renderingMode(.template)
                     Text("홈")
                 }
-            MapView.build()
+                .tag(Tab.home)
+
+            coordinator.build(.map) // 산책하기 화면 생성
                 .tabItem {
                     Image.asWalk
                         .renderingMode(.template)
                     Text("산책하기")
                 }
-            CommunityView.build()
+                .tag(Tab.dogWalk)
+
+            coordinator.build(.community) // 커뮤니티 화면 생성
                 .tabItem {
                     Image.asWalk
                         .renderingMode(.template)
                     Text("커뮤니티")
                 }
-            ChattingListView.build()
+                .tag(Tab.community)
+
+            coordinator.build(.chatting) // 멍톡 화면 생성
                 .tabItem {
                     Image.asWalk
                         .renderingMode(.template)
                     Text("멍톡")
                 }
+                .tag(Tab.chatting)
         }
         .tint(Color.primaryGreen)
+        .navigationBarBackButtonHidden()
     }
-}
-
-#Preview {
-    CustomTabView()
 }

--- a/DogWalk/Presentatiton/Screens/Home/HomeView.swift
+++ b/DogWalk/Presentatiton/Screens/Home/HomeView.swift
@@ -92,9 +92,14 @@ extension HomeView {
     //MARK: 함께 산책하기, 산책 인증하기 뷰
     func middleButtonSView() -> some View {
         HStack(spacing: 20) {
-            //버튼들
             CommonButton(width: 170, height: 50, cornerradius: 20, backColor: .primaryGreen, text: "함께 산책하기  🐾", textFont: .pretendardSemiBold18)
+                .wrapToButton {
+                    coordinator.changeTab(tab: .dogWalk)
+                }
             CommonButton(width: 170, height: 50, cornerradius: 20, backColor: .primaryLime, text: "산책 인증하기", textFont: .pretendardSemiBold18, rightLogo: .asTestLogo, imageSize: 20)
+                .wrapToButton {
+                    coordinator.changeTab(tab: .community)
+                }
         }
         .padding(.vertical,10)
     }


### PR DESCRIPTION
## 📁 PR 타입
- [x] 기능 작업
- [ ] UI 작업
- [ ] 버그 수정
- [x] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## ✅ 작업 내용
<!-- 작업한 내용 기록 -->
- LoginView -> MainTab 이동시 뒤로가기 버튼 없애기
- HomeView 함께 산책하기, 산책 인증하기 버튼 탭 시 해당 탭으로 이동 기능 추가
<br />

## 📱 스크린샷
<!-- 작업 결과 스크린샷 기록 -->
![Simulator Screen Recording - iPhone 15 Pro - 2024-11-24 at 20 11 10](https://github.com/user-attachments/assets/ffa589bb-0859-4560-846a-8009c8805424)

<br /><br />

## ⛓️ 관련 issue
<!-- e.g) closed #이슈번호 -->
closed #107 
<br />

## 🗣️ 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분 기록 -->
<!-- 없으면 삭제! -->

<br />

## 📋 메모
<!-- 간단히 메모가 필요하거나 공유되어야 하는 사항 기록 -->
<!-- 없으면 삭제! -->
파이팅!